### PR TITLE
lputil: Proper support for big-endian platforms with the various Read*() functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,5 +54,11 @@ if(${LUNAPURPURA_DEBUG})
   add_definitions(-DLUNAPURPURA_DEBUG)
 endif()
 
+include(TestBigEndian)
+test_big_endian(LUNAPURPURA_BIG_ENDIAN)
+if(${LUNAPURPURA_BIG_ENDIAN})
+  add_definitions(-DLUNAPURPURA_BIG_ENDIAN)
+endif()
+
 # Good to go.
 add_subdirectory(src)

--- a/src/lputil/lputil.c
+++ b/src/lputil/lputil.c
@@ -184,7 +184,9 @@ size_t
 ReadUint16(FILE *file, size_t count, uint16_t *dest)
 {
 	size_t rv = fread(dest, sizeof(uint16_t), count, file);
+#ifndef LUNAPURPURA_BIG_ENDIAN
 	*dest = htons(*dest);
+#endif
 	return rv;
 }
 
@@ -197,7 +199,9 @@ size_t
 ReadUint16LE(FILE *file, size_t count, uint16_t *dest)
 {
 	size_t rv = fread(dest, sizeof(uint16_t), count, file);
-	/* XXX do something to guarantee it was little-endian */
+#ifdef LUNAPURPURA_BIG_ENDIAN
+	*dest = ntohs(*dest);
+#endif
 	return rv;
 }
 
@@ -210,7 +214,9 @@ size_t
 ReadUint32(FILE *file, size_t count, uint32_t *dest)
 {
 	size_t rv = fread(dest, sizeof(uint32_t), count, file);
+#ifndef LUNAPURPURA_BIG_ENDIAN
 	*dest = htonl(*dest);
+#endif
 	return rv;
 }
 
@@ -223,6 +229,8 @@ size_t
 ReadUint32LE(FILE *file, size_t count, uint32_t *dest)
 {
 	size_t rv = fread(dest, sizeof(uint32_t), count, file);
-	/* XXX do something to guarantee it was little-endian */
+#ifdef LUNAPURPURA_BIG_ENDIAN
+	*dest = ntohl(*dest);
+#endif
 	return rv;
 }


### PR DESCRIPTION
Determine at configure-time whether we're building for a big-endian or a little-endian machine, which in turn will enable or disable such things as htons(3) from happening

---

I'm putting this up as a pull request because I want to make sure this is right. The real test is to actually get this thing built on a big-endian machine. I plan on using QEMU to help out with testing, since I only have Intel hardware on hand 