### PR TITLE
PRX: Add the numerical RID to the names of extracted files

### DIFF
--- a/src/prx/main.c
+++ b/src/prx/main.c
@@ -19,7 +19,11 @@
 
 #define PARSE_OPTIONS_OK (-1)
 
-#define PRX_TOTAL_FILENAME_LEN (PRXMEMBER_NAME_LEN + PRXMEMBER_FILETYPE_LEN)
+/*
+ * A RID is a 32-bit unsigned int, whose decimal expansion takes up to 10
+ * characters, plus one for the separator. Therefore, 11.
+ */
+#define PRX_TOTAL_FILENAME_LEN (11 + PRXMEMBER_NAME_LEN + PRXMEMBER_FILETYPE_LEN)
 
 enum PRXToolAction {
 	PRX_TOOL_ACTION_NONE,
@@ -114,7 +118,7 @@ main(int argc, char *argv[])
 					}
 				} else {
 					char total_filename[PRX_TOTAL_FILENAME_LEN];
-					snprintf(total_filename, PRX_TOTAL_FILENAME_LEN, "%s.%s", member->name, member->filetype);
+					snprintf(total_filename, PRX_TOTAL_FILENAME_LEN, "%u-%s.%s", member->rid, member->name, member->filetype);
 					fp = fopen(total_filename, "wb");
 				}
 


### PR DESCRIPTION
FYI @AlanisSmithee

It turns out there are plenty of examples of PRX members which all have the
same name, *especially* in First Dance. Up until now, the prx(1) tool has
been happily overwriting these files with conflicting names.

It's not a bug in the PRX decoder... these filenames (I'm looking inside of
Dance's IDGLASS.PRX) literally have truncated names. Rather unfortunate.

I've opted to prepend the RID to the filename, separated by a dash.  Seems
easy to parse, at least visually. Unfortunately, there are filenames in some
PRXes which themselves have dashes, so it's not the easiest thing to script
around... I'm open to changing this convention, though. Not sure what's best.